### PR TITLE
fix https://github.com/frndotmsn/SE2Laborphase2/issues/8#issuecomment…

### DIFF
--- a/src/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java
+++ b/src/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java
@@ -110,15 +110,37 @@ public class Vormerkkarte
         _vormerkende.remove();
     }
     
+    
     /**
      * Gibt zurück, ob Vormerken möglich ist.
      * Dies trifft zu, wenn die Anzahl der Vormerkenden unter 3 ist.
-     * 
+     *  
      * @return ob Vormerken Möglich ist
+     * 
+     * @require kunde != null
+     * 
+     * @deprecated es sollte istVormerkenMoeglich(Kunde) verwendet werden
      */
     public boolean istVormerkenMoeglich()
     {
-        return _vormerkende.size() < 3;
+        return maximaleAnzahlVormerkendeErreicht();
+    }
+    
+    /**
+     * Gibt zurück, ob Vormerken durch einen bestimmten Kunden möglich ist.
+     * Dies trifft zu, wenn die Anzahl der Vormerkenden unter 3 ist.
+     * Der Kunde darf zusätzlich nicht Vormerker sein.
+     * 
+     * @param kunde Kunde
+     * 
+     * @return ob Vormerken Möglich ist
+     * 
+     * @require kunde != null
+     */
+    public boolean istVormerkenMoeglich(Kunde kunde)
+    {
+        assert kunde != null : "Vorbedingung verletzt: kunde != null";
+        return maximaleAnzahlVormerkendeErreicht() && !istVormerker(kunde);
     }
     
     /**
@@ -164,5 +186,16 @@ public class Vormerkkarte
     public boolean istVormerker(Kunde kunde)
     {
         return _vormerkende.contains(kunde);
+    }
+    
+    /**
+     * Gibt zurück, ob diese Vormerkkarte schon die maximale Anzahl der Vormerker erreicht hat.
+     * Die Maximale Anzahl der Vormerker ist 3.
+     *
+     * @return ob die Anzahl der Vormerker größer gleich der Maximalen ist.
+     */
+    private boolean maximaleAnzahlVormerkendeErreicht()
+    {
+        return _vormerkende.size() < 3;
     }
 }


### PR DESCRIPTION
Die Schnittstelle von Vormerkkarte wurde entsprechend zum UML-Diagramm geupdated. Jetzt gibt es Vormerkkarte.istVormerkenMoeglich(Kunde) https://github.com/frndotmsn/SE2Laborphase2/blob/6b43525c0de0abd717ebda13a24040a3df6d4ad9/src/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java#L129-L144, da zuvor kein Kunde als Parameter an Vormerkkarte.istVormerkenMoeglich() https://github.com/frndotmsn/SE2Laborphase2/blob/80f84f06bfb80894f89a508081023b688d8dd63c/src/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java#L113-L122 weitergegeben werden konnte, konnte auch nicht innerhalb der Vormerkkarte geprüft werden, ob der Kunde schon unter den Vormerkenden ist. Dies hätte zwar auch in VormerkServiceImpl geregelt werden können, ich entschied mich jedoch dazu es in Vormerkkarte zu machen.
Die alte Variante besteht fort, ist nun aber deprecated https://github.com/frndotmsn/SE2Laborphase2/blob/6b43525c0de0abd717ebda13a24040a3df6d4ad9/src/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java#L114-L127. 