### PR TITLE
Die Vormerk Ansicht funktioniert jetzt wie gewollt

### DIFF
--- a/src/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/vormerkmedienauflister/VormerkMedienauflisterWerkzeug.java
+++ b/src/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/vormerkmedienauflister/VormerkMedienauflisterWerkzeug.java
@@ -8,10 +8,12 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Kunde;
+import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Vormerkkarte;
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.medien.Medium;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.ServiceObserver;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.medienbestand.MedienbestandService;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.verleih.VerleihService;
+import de.uni_hamburg.informatik.swt.se2.mediathek.services.vormerk.VormerkService;
 import de.uni_hamburg.informatik.swt.se2.mediathek.ui.ObservableSubWerkzeug;
 
 /**
@@ -29,6 +31,7 @@ public class VormerkMedienauflisterWerkzeug extends ObservableSubWerkzeug
     private VormerkMedienauflisterUI _ui;
     private MedienbestandService _medienbestand;
     private final VerleihService _verleihService;
+    private final VormerkService _vormerkService;
 
     /**
      * Initialisiert ein neues VormerkMedienauflisterWerkzeug. Es wird die
@@ -36,18 +39,22 @@ public class VormerkMedienauflisterWerkzeug extends ObservableSubWerkzeug
      * 
      * @param medienbestand Der Medienbestand.
      * @param verleihService Der Verleih-Service.
+     * @param vormerkService Der Vormerk-Service
      * 
      * @require medienbestand != null
      * @require verleihService != null
+     * @require vormerkService != null
      */
     public VormerkMedienauflisterWerkzeug(MedienbestandService medienbestand,
-            VerleihService verleihService)
+            VerleihService verleihService, VormerkService vormerkService)
     {
         assert medienbestand != null : "Vorbedingung verletzt: medienbestand != null";
         assert verleihService != null : "Vorbedingung verletzt: verleihService != null";
+        assert vormerkService != null : "Vorbedingung verletzt: vormerkService != null";
 
         _medienbestand = medienbestand;
         _verleihService = verleihService;
+        _vormerkService = vormerkService;
 
         // UI wird erzeugt.
         _ui = new VormerkMedienauflisterUI();
@@ -84,10 +91,18 @@ public class VormerkMedienauflisterWerkzeug extends ObservableSubWerkzeug
             // Entleiher und möglichen Vormerkern ausgestattet werden.
             // Ist dies korrekt implementiert, erscheinen in der Vormerkansicht
             // die Namen des Entleihers und der möglichen 3 Vormerker.
+            
             Kunde entleiher = null;
-            Kunde vormerker1 = null;
-            Kunde vormerker2 = null;
-            Kunde vormerker3 = null;
+            if (_verleihService.istVerliehen(medium))
+            {
+                entleiher = _verleihService.getEntleiherFuer(medium);                
+            }
+            
+            Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(medium);
+            
+            Kunde vormerker1 = vormerkkarte.getErsterVormerker();
+            Kunde vormerker2 = vormerkkarte.getZweiterVormerker();
+            Kunde vormerker3 = vormerkkarte.getDritterVormerker();
 
             medienFormatierer.add(new VormerkMedienFormatierer(medium,
                     entleiher, vormerker1, vormerker2, vormerker3));
@@ -131,6 +146,7 @@ public class VormerkMedienauflisterWerkzeug extends ObservableSubWerkzeug
         };
         _medienbestand.registriereBeobachter(beobachter);
         _verleihService.registriereBeobachter(beobachter);
+        _vormerkService.registriereBeobachter(beobachter);
     }
 
     /**

--- a/src/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
+++ b/src/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
@@ -94,7 +94,7 @@ public class VormerkWerkzeug
         // Subwerkzeuge erstellen
         _kundenAuflisterWerkzeug = new KundenauflisterWerkzeug(kundenstamm);
         _medienAuflisterWerkzeug = new VormerkMedienauflisterWerkzeug(
-                medienbestand, verleihService);
+                medienbestand, verleihService, vormerkService);
         _medienDetailAnzeigerWerkzeug = new MedienDetailAnzeigerWerkzeug();
         _kundenDetailAnzeigerWerkzeug = new KundenDetailAnzeigerWerkzeug();
 


### PR DESCRIPTION
VormerkMedienauflisterWerkzeug beinhaltet die Vormerker aus VormerkService, beim Ändern der Vormerkung über den VormerkService updaten sich die Vormerker in der Ansicht per Observer-Pattern