### PR TITLE
VormerkService & VerleihService entkoppelt, #36 und #40 implementiert

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+#
+#Fri May 24 13:49:13 CEST 2024
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/Vormerkkarte.java
@@ -23,7 +23,7 @@ public class Vormerkkarte
 {
     private final Medium _medium;
     private final LinkedList<Kunde> _vormerkende;
-    
+
     /**
      * Initialisert eine neue Vormerkkarte mit den gegebenen Daten.
      * 
@@ -40,7 +40,7 @@ public class Vormerkkarte
         _medium = medium;
         _vormerkende = new LinkedList<Kunde>();
     }
-    
+
     /**
      * Gibt das Medium der Vormerkkarte zurück.
      * 
@@ -52,7 +52,7 @@ public class Vormerkkarte
     {
         return _medium;
     }
-    
+
     /**
      * Gibt den ersten Vormerker zurück.
      * 
@@ -64,10 +64,10 @@ public class Vormerkkarte
         {
             return null;
         }
-        
+
         return _vormerkende.get(0);
     }
-    
+
     /**
      * Gibt den zweiten Vormerker zurück.
      * 
@@ -79,10 +79,10 @@ public class Vormerkkarte
         {
             return null;
         }
-        
+
         return _vormerkende.get(1);
     }
-    
+
     /**
      * Gibt den dritten Vormerker zurück.
      * 
@@ -94,10 +94,10 @@ public class Vormerkkarte
         {
             return null;
         }
-        
+
         return _vormerkende.get(2);
     }
-    
+
     /**
      * Entfernt den ersten Vormerker.
      * 
@@ -106,11 +106,10 @@ public class Vormerkkarte
     public void entferneErstenVormerker()
     {
         assert !istLeer() : "Vorbedingung verletzt: !istLeer()";
-        
+
         _vormerkende.poll();
     }
-    
-    
+
     /**
      * Gibt zurück, ob Vormerken möglich ist.
      * Dies trifft zu, wenn die Anzahl der Vormerkenden unter 3 ist.
@@ -121,11 +120,12 @@ public class Vormerkkarte
      * 
      * @deprecated es sollte istVormerkenMoeglich(Kunde) verwendet werden
      */
+    @Deprecated
     public boolean istVormerkenMoeglich()
     {
         return !maximaleAnzahlVormerkendeErreicht();
     }
-    
+
     /**
      * Gibt zurück, ob Vormerken durch einen bestimmten Kunden möglich ist.
      * Dies trifft zu, wenn die Anzahl der Vormerkenden unter 3 ist.
@@ -142,7 +142,7 @@ public class Vormerkkarte
         assert kunde != null : "Vorbedingung verletzt: kunde != null";
         return !maximaleAnzahlVormerkendeErreicht() && !istVormerker(kunde);
     }
-    
+
     /**
      * Gibt zurück, ob die Vormerkkarte leer ist.
      * Dass heißt, ob sie keine Vormerker hat.
@@ -153,7 +153,7 @@ public class Vormerkkarte
     {
         return _vormerkende.size() == 0;
     }
-    
+
     /**
      * Merkt den Kunden als Vormerker vor.
      * 
@@ -165,16 +165,17 @@ public class Vormerkkarte
      * 
      * @ensure !{@link #istLeer()}
      */
-    
+
     // TODO: merkeVor soll maybe boolean zurückgeben, ob das Vormerken geklappt hat
     public void merkeVor(Kunde kunde)
     {
         assert kunde != null : "Vorbedingung verletzt: kunde != null";
-        assert istVormerkenMoeglich(kunde) : "Vorbedingung verletzt: istVormerkenMoeglich()";
-        
+        assert istVormerkenMoeglich(
+                kunde) : "Vorbedingung verletzt: istVormerkenMoeglich()";
+
         _vormerkende.offer(kunde);
     }
-    
+
     /**
      * Gibt zurück, ob der Kunde ein Vormerker ist.
      * 
@@ -185,7 +186,7 @@ public class Vormerkkarte
     {
         return _vormerkende.contains(kunde);
     }
-    
+
     /**
      * Gibt zurück, ob diese Vormerkkarte schon die maximale Anzahl der Vormerker erreicht hat.
      * Die Maximale Anzahl der Vormerker ist 3.

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/persistenz/KundenEinleser.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/persistenz/KundenEinleser.java
@@ -44,7 +44,8 @@ class KundenEinleser
         assert kundenDatei != null : "Vorbedingung verletzt: kundenDatei != null";
         List<Kunde> eingeleseneKunden = new ArrayList<Kunde>();
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(kundenDatei)))
+        try (BufferedReader reader = new BufferedReader(
+                new FileReader(kundenDatei)))
         {
             String line = null;
             // liest Datei Zeile für Zeile

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/persistenz/MedienEinleser.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/persistenz/MedienEinleser.java
@@ -129,7 +129,8 @@ class MedienEinleser
         assert medienDatei != null : "Vorbedingung verletzt: medienDatei != null";
         Map<Medium, Verleihkarte> eingeleseneMedien = new HashMap<Medium, Verleihkarte>();
 
-        try (BufferedReader reader = new BufferedReader(new FileReader(medienDatei)))
+        try (BufferedReader reader = new BufferedReader(
+                new FileReader(medienDatei)))
         {
             Map<Kundennummer, Kunde> kundenMap = new HashMap<Kundennummer, Kunde>();
             for (Kunde kunde : kundenstamm)

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihService.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihService.java
@@ -6,6 +6,7 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Kunde;
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Verleihkarte;
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.medien.Medium;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.ObservableService;
+import de.uni_hamburg.informatik.swt.se2.mediathek.services.vormerk.VormerkService;
 import de.uni_hamburg.informatik.swt.se2.mediathek.wertobjekte.Datum;
 
 /**
@@ -30,24 +31,28 @@ public interface VerleihService extends ObservableService
      * @param kunde Ein Kunde, an den ein Medium verliehen werden soll
      * @param medien Die Medien, die verliehen werden sollen
      * @param ausleihDatum Der erste Ausleihtag
+     * @param vormerkService Der VormerkService
      * 
      * @throws ProtokollierException Wenn beim Protokollieren des
      *             Verleihvorgangs ein Fehler auftritt.
      * 
      * @require kundeImBestand(kunde)
-     * @require sindAlleNichtVerliehen(medien)
+     * @require {@link #istVormerkenMoeglich(kunde, medien, vormerkService)}
+     *
      * @require ausleihDatum != null
+     * @require vormerkService != null
      * 
      * @ensure sindAlleVerliehenAn(kunde, medien)
      */
-    void verleiheAn(Kunde kunde, List<Medium> medien, Datum ausleihDatum)
-            throws ProtokollierException;
+    void verleiheAn(Kunde kunde, List<Medium> medien, Datum ausleihDatum,
+            VormerkService vormerkService) throws ProtokollierException;
 
     /**
      * Prüft ob die ausgewählten Medium für den Kunde ausleihbar sind
      * 
      * @param kunde Der Kunde für den geprüft werden soll
      * @param medien Die medien
+     * @param vormerkService Der VormerkService
      * 
      * 
      * @return true, wenn das Entleihen für diesen Kunden möglich ist, sonst
@@ -55,8 +60,10 @@ public interface VerleihService extends ObservableService
      * 
      * @require kundeImBestand(kunde)
      * @require medienImBestand(medien)
+     * @require vormerkService != null
      */
-    boolean istVerleihenMoeglich(Kunde kunde, List<Medium> medien);
+    boolean istVerleihenMoeglich(Kunde kunde, List<Medium> medien,
+            VormerkService vormerkService);
 
     /**
      * Liefert den Entleiher des angegebenen Mediums.

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkService.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkService.java
@@ -6,6 +6,7 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Kunde;
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.Vormerkkarte;
 import de.uni_hamburg.informatik.swt.se2.mediathek.entitaeten.medien.Medium;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.ObservableService;
+import de.uni_hamburg.informatik.swt.se2.mediathek.services.verleih.VerleihService;
 
 /**
  * Der VormerkService erlaubt es, Medien vorzumerken.
@@ -27,26 +28,31 @@ public interface VormerkService extends ObservableService
      * 
      * @param kunde der Kunde, der Vormerker werden soll
      * @param medium das vorzumerkende Medium
+     * @param verleihService Der verleihService
      * 
      * @require kunde != null
      * @require medium != null
-     * @require {@link #istVormerkenMoeglich(kunde, medium)}
+     * @require {@link #istVormerkenMoeglich(kunde, medium, verleihService)}
      */
     // TODO: merkeVor soll maybe boolean zurückgeben, ob das Vormerken geklappt hat
-    public void merkeVor(Kunde kunde, Medium medium);
-    
+    public void merkeVor(Kunde kunde, Medium medium,
+            VerleihService verleihService);
+
     /**
      * Gibt zurück, ob der Kunde das Medium vormerken kann.
      * 
      * @param kunde der Kunde
      * @param medium das Medium
+     * @param verleihService Der VerleihService
      * @return ob der Kunde das Medium vormerken kann
      * 
      * @require kunde != null
      * @require medium != null
+     * @require verleihService != null
      */
-    public boolean istVormerkenMoeglich(Kunde kunde, Medium medium);
-    
+    public boolean istVormerkenMoeglich(Kunde kunde, Medium medium,
+            VerleihService verleihService);
+
     /**
      * Entfernt die ersten Vormerker der Medien falls dieser dem Kunden entspricht.
      * Falls es keinen ersten Vormerker gibt oder der Kunde diesem nicht entspricht passiert nichts.
@@ -58,7 +64,7 @@ public interface VormerkService extends ObservableService
      * @require medien != null
      */
     public void entferneErstenVormerker(Kunde kunde, List<Medium> medien);
-    
+
     /**
      * Gibt die zugehörige Vormerkkarte zum Medium zurück.
      * 
@@ -70,4 +76,15 @@ public interface VormerkService extends ObservableService
      * @ensure result != null
      */
     public Vormerkkarte getVormerkkarte(Medium medium);
+
+    /**
+     * Gibt zurück, ob der Kunde aller Vormerker der Medien ist, falls diese Vormerker haben
+     * 
+     * @param kunde Der kunde
+     * @param medien Die Medien
+     * 
+     * @return ob der Kunde Vormerker der Medien ist, falls diese Vormerker haben
+     */
+    public boolean istVormerkerOderLeereVormerkkarte(Kunde kunde,
+            List<Medium> medien);
 }

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImpl.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImpl.java
@@ -14,63 +14,76 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.services.verleih.VerleihServi
  * Diese Klasse implementiert das Interface VormerkService. Siehe dortiger
  * Kommentar.
  */
-public class VormerkServiceImpl extends AbstractObservableService implements VormerkService
+public class VormerkServiceImpl extends AbstractObservableService
+        implements VormerkService
 {
-    private final VerleihService _verleihService;
-    private final Map<Medium, Vormerkkarte> _vormerkkarten;
-    
-    public VormerkServiceImpl(VerleihService verleihService)
+    protected final Map<Medium, Vormerkkarte> _vormerkkarten;
+
+    public VormerkServiceImpl()
     {
-        _verleihService = verleihService;
-        _vormerkkarten = new HashMap<Medium, Vormerkkarte>();
+        _vormerkkarten = new HashMap<>();
     }
-    
+
     @Override
-    public void merkeVor(Kunde kunde, Medium medium)
+    public void merkeVor(Kunde kunde, Medium medium,
+            VerleihService verleihService)
     {
         assert medium != null : "Vorbedingung verletzt: medium != null";
         assert kunde != null : "Vorbedingung verletzt: kunde != null";
-        assert istVormerkenMoeglich(kunde, medium) : "Vorbedingung verletzt: istVormerkenMoeglich(kunde, medium)";
-        
+        assert istVormerkenMoeglich(kunde, medium,
+                verleihService) : "Vorbedingung verletzt: istVormerkenMoeglich(kunde, medium)";
+
         Vormerkkarte vormerkkarte = getVormerkkarte(medium);
+        if (vormerkkarte == null)
+        {
+            vormerkkarte = new Vormerkkarte(medium);
+            _vormerkkarten.put(medium, vormerkkarte);
+        }
         vormerkkarte.merkeVor(kunde);
         // falls vormerken erfolgreich, informieren über Änderung!
         informiereUeberAenderung();
     }
 
     @Override
-    public boolean istVormerkenMoeglich(Kunde kunde, Medium medium)
+    public boolean istVormerkenMoeglich(Kunde kunde, Medium medium,
+            VerleihService verleihService)
     {
         // Der Kunde, der das Medium momentan ausgeliehen hat, darf es nicht vormerken
-        if (_verleihService.istVerliehenAn(kunde, medium))
+        if (verleihService.istVerliehenAn(kunde, medium))
         {
             return false;
         }
-        
+
         Vormerkkarte vormerkkarte = getVormerkkarte(medium);
-        
-        return vormerkkarte.istVormerkenMoeglich(kunde);
+
+        return vormerkkarte == null || vormerkkarte.istVormerkenMoeglich(kunde);
     }
 
     @Override
     public Vormerkkarte getVormerkkarte(Medium medium)
     {
-        return _vormerkkarten.computeIfAbsent(medium, (x) -> new Vormerkkarte(x));
+        Vormerkkarte vormerkkarte = _vormerkkarten.get(medium);
+        if (vormerkkarte == null)
+        {
+            vormerkkarte = new Vormerkkarte(medium);
+            _vormerkkarten.put(medium, vormerkkarte);
+        }
+        return vormerkkarte;
     }
-    
+
     @Override
     public void entferneErstenVormerker(Kunde kunde, List<Medium> medien)
     {
         assert kunde != null : "Vorbedingung verletzt: kunde != null";
         assert medien != null : "Vorbedingung verletzt: medien != null";
-        
+
         for (Medium medium : medien)
         {
             entferneErstenVormerker(kunde, medium);
         }
         informiereUeberAenderung();
     }
-    
+
     /**
      * Entfernt den ersten Vormerker eines Mediums.
      * 
@@ -86,9 +99,10 @@ public class VormerkServiceImpl extends AbstractObservableService implements Vor
     {
         assert kunde != null : "Vorbedingung verletzt: kunde != null";
         assert medium != null : "Vorbedingung verletzt: medium != null";
-        
+
         Vormerkkarte vormerkkarte = getVormerkkarte(medium);
-        if (vormerkkarte.getErsterVormerker() == kunde)
+        if (vormerkkarte != null
+                && kunde.equals(vormerkkarte.getErsterVormerker()))
         {
             vormerkkarte.entferneErstenVormerker();
             return true;
@@ -97,5 +111,21 @@ public class VormerkServiceImpl extends AbstractObservableService implements Vor
         {
             return false;
         }
+    }
+
+    @Override
+    public boolean istVormerkerOderLeereVormerkkarte(Kunde kunde,
+            List<Medium> medien)
+    {
+        for (Medium medium : medien)
+        {
+            Kunde vormerker = getVormerkkarte(medium).getErsterVormerker();
+            if (!kunde.equals(vormerker) && vormerker != null)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/startup/StartUpMediathek_Blatt06.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/startup/StartUpMediathek_Blatt06.java
@@ -70,9 +70,9 @@ public class StartUpMediathek_Blatt06
                     datenEinleser.getMedien());
             _kundenstamm = new KundenstammServiceImpl(
                     datenEinleser.getKunden());
+            _vormerkService = new VormerkServiceImpl();
             _verleihService = new VerleihServiceImpl(_kundenstamm,
                     _medienbestand, datenEinleser.getVerleihkarten());
-            _vormerkService = new VormerkServiceImpl(_verleihService);
         }
         catch (DateiLeseException e)
         {

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/ausleihe/AusleihWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/ausleihe/AusleihWerkzeug.java
@@ -249,7 +249,8 @@ public class AusleihWerkzeug
         try
         {
             Datum heute = Datum.heute();
-            _verleihService.verleiheAn(selectedKunde, selectedMedien, heute);
+            _verleihService.verleiheAn(selectedKunde, selectedMedien, heute,
+                    _vormerkService);
         }
         catch (ProtokollierException exception)
         {

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/hauptwerkzeug/MediathekWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/hauptwerkzeug/MediathekWerkzeug.java
@@ -68,13 +68,14 @@ public class MediathekWerkzeug
      * @require vormerkService != null
      */
     public MediathekWerkzeug(MedienbestandService medienbestand,
-            KundenstammService kundenstamm, VerleihService verleihService, VormerkService vormerkService)
+            KundenstammService kundenstamm, VerleihService verleihService,
+            VormerkService vormerkService)
     {
         assert medienbestand != null : "Vorbedingung verletzt: medienbestand != null";
         assert kundenstamm != null : "Vorbedingung verletzt: kundenstamm != null";
         assert verleihService != null : "Vorbedingung verletzt: verleihService != null";
         assert vormerkService != null : "Vorbedingung verletzt: vormerkService != null";
-        
+
         _medienbestand = medienbestand;
         _kundenstamm = kundenstamm;
         _verleihService = verleihService;

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/ausleihemedienauflister/AusleiheMedienauflisterWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/ausleihemedienauflister/AusleiheMedienauflisterWerkzeug.java
@@ -91,7 +91,8 @@ public class AusleiheMedienauflisterWerkzeug extends ObservableSubWerkzeug
             // Ist dies korrekt implementiert, erscheint in der Ausleiheansicht
             // der Name des Vormerkers, an den ein Medium ausgeliehen werden
             // darf, gemäß Anforderung c).
-            Kunde ersterVormerker = _vormerkService.getVormerkkarte(medium).getErsterVormerker();
+            Kunde ersterVormerker = _vormerkService.getVormerkkarte(medium)
+                .getErsterVormerker();
 
             medienFormatierer.add(new AusleiheMedienFormatierer(medium,
                     istVerliehen, ersterVormerker));

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/vormerkmedienauflister/VormerkMedienauflisterWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/subwerkzeuge/vormerkmedienauflister/VormerkMedienauflisterWerkzeug.java
@@ -91,15 +91,15 @@ public class VormerkMedienauflisterWerkzeug extends ObservableSubWerkzeug
             // Entleiher und möglichen Vormerkern ausgestattet werden.
             // Ist dies korrekt implementiert, erscheinen in der Vormerkansicht
             // die Namen des Entleihers und der möglichen 3 Vormerker.
-            
+
             Kunde entleiher = null;
             if (_verleihService.istVerliehen(medium))
             {
-                entleiher = _verleihService.getEntleiherFuer(medium);                
+                entleiher = _verleihService.getEntleiherFuer(medium);
             }
-            
+
             Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(medium);
-            
+
             Kunde vormerker1 = vormerkkarte.getErsterVormerker();
             Kunde vormerker2 = vormerkkarte.getZweiterVormerker();
             Kunde vormerker3 = vormerkkarte.getDritterVormerker();

--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
@@ -242,9 +242,11 @@ public class VormerkWerkzeug
         // TODO für Aufgabenblatt 6 (nicht löschen): Vormerken einbauen
         for (Medium medium : selectedMedien)
         {
-            if (_vormerkService.istVormerkenMoeglich(selectedKunde, medium))
+            if (_vormerkService.istVormerkenMoeglich(selectedKunde, medium,
+                    _verleihService))
             {
-                _vormerkService.merkeVor(selectedKunde, medium);
+                _vormerkService.merkeVor(selectedKunde, medium,
+                        _verleihService);
             }
             else
             {

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/VormerkkarteTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/VormerkkarteTest.java
@@ -8,38 +8,38 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.wertobjekte.Kundennummer;
 
 import static org.junit.Assert.*;
 
-public class VormerkkarteTest 
+public class VormerkkarteTest
 {
-	private Vormerkkarte _vormerkkarte;
-	private Medium _medium;
-	private Kunde _kunde1;
-	private Kunde _kunde2;
-	private Kunde _kunde3;
-	private Kunde _kunde4;
-	
-	public VormerkkarteTest()
-	{
-		_medium = new CD("Titel", "Kommentar", "Interpret", 123);
-		_vormerkkarte = new Vormerkkarte(_medium);
-		
-		_kunde1 = new Kunde(new Kundennummer(111111), "Max", "Mustermann");
-		_kunde2 = new Kunde(new Kundennummer(222222), "Lisa", "Mueller");
-		_kunde3 = new Kunde(new Kundennummer(333333), "Thorsten", "Schmidt");
-		_kunde4 = new Kunde(new Kundennummer(444444), "Karsten", "Koch");
-	}
-	
-	@Test
-	public void testeKonstruktor()
-	{
-		assertEquals(_medium, _vormerkkarte.getMedium());
-		assertTrue(_vormerkkarte.istLeer());
-		assertFalse(_vormerkkarte.istVormerker(_kunde1));
-	}
-	
-	@Test
-	public void testgetVormerkerundEntferneVormerker()
-	{
-		_vormerkkarte.merkeVor(_kunde1);
+    private Vormerkkarte _vormerkkarte;
+    private Medium _medium;
+    private Kunde _kunde1;
+    private Kunde _kunde2;
+    private Kunde _kunde3;
+    private Kunde _kunde4;
+
+    public VormerkkarteTest()
+    {
+        _medium = new CD("Titel", "Kommentar", "Interpret", 123);
+        _vormerkkarte = new Vormerkkarte(_medium);
+
+        _kunde1 = new Kunde(new Kundennummer(111111), "Max", "Mustermann");
+        _kunde2 = new Kunde(new Kundennummer(222222), "Lisa", "Mueller");
+        _kunde3 = new Kunde(new Kundennummer(333333), "Thorsten", "Schmidt");
+        _kunde4 = new Kunde(new Kundennummer(444444), "Karsten", "Koch");
+    }
+
+    @Test
+    public void testeKonstruktor()
+    {
+        assertEquals(_medium, _vormerkkarte.getMedium());
+        assertTrue(_vormerkkarte.istLeer());
+        assertFalse(_vormerkkarte.istVormerker(_kunde1));
+    }
+
+    @Test
+    public void testgetVormerkerundEntferneVormerker()
+    {
+        _vormerkkarte.merkeVor(_kunde1);
         assertFalse(_vormerkkarte.istLeer());
         assertTrue(_vormerkkarte.istVormerker(_kunde1));
         assertEquals(_kunde1, _vormerkkarte.getErsterVormerker());
@@ -54,41 +54,41 @@ public class VormerkkarteTest
         assertEquals(_kunde1, _vormerkkarte.getErsterVormerker());
         assertEquals(_kunde2, _vormerkkarte.getZweiterVormerker());
         assertEquals(_kunde3, _vormerkkarte.getDritterVormerker());
- 
+
         _vormerkkarte.entferneErstenVormerker();
-		assertFalse(_vormerkkarte.istVormerker(_kunde1));
-		assertEquals(_kunde2, _vormerkkarte.getErsterVormerker());
-		assertEquals(_kunde3, _vormerkkarte.getZweiterVormerker());
-		assertNull(_vormerkkarte.getDritterVormerker());
-		
-		_vormerkkarte.entferneErstenVormerker();
-		assertFalse(_vormerkkarte.istVormerker(_kunde2));
-		assertEquals(_kunde3, _vormerkkarte.getErsterVormerker());
-		assertNull(_vormerkkarte.getZweiterVormerker());
-		assertNull(_vormerkkarte.getDritterVormerker());
-		
-		_vormerkkarte.entferneErstenVormerker();
-		assertFalse(_vormerkkarte.istVormerker(_kunde3));
-		assertTrue(_vormerkkarte.istLeer());
-	}
-	
-	@Test
-	public void testistVormerkenMoeglich()
-	{
-		Vormerkkarte vormerkkarteMoeglich = new Vormerkkarte(_medium);
-		assertTrue(vormerkkarteMoeglich.istVormerkenMoeglich(_kunde1));
-		vormerkkarteMoeglich.merkeVor(_kunde1);
-		vormerkkarteMoeglich.merkeVor(_kunde2);
-		vormerkkarteMoeglich.merkeVor(_kunde3);
-		assertFalse(vormerkkarteMoeglich.istVormerkenMoeglich(_kunde4));
-	}
-	
-	@Test
-	public void testIstVormerker()
-	{
-		_vormerkkarte.merkeVor(_kunde1);
-		assertTrue(_vormerkkarte.istVormerker(_kunde1));
-		assertFalse(_vormerkkarte.istVormerker(_kunde2));
-	}
-	
+        assertFalse(_vormerkkarte.istVormerker(_kunde1));
+        assertEquals(_kunde2, _vormerkkarte.getErsterVormerker());
+        assertEquals(_kunde3, _vormerkkarte.getZweiterVormerker());
+        assertNull(_vormerkkarte.getDritterVormerker());
+
+        _vormerkkarte.entferneErstenVormerker();
+        assertFalse(_vormerkkarte.istVormerker(_kunde2));
+        assertEquals(_kunde3, _vormerkkarte.getErsterVormerker());
+        assertNull(_vormerkkarte.getZweiterVormerker());
+        assertNull(_vormerkkarte.getDritterVormerker());
+
+        _vormerkkarte.entferneErstenVormerker();
+        assertFalse(_vormerkkarte.istVormerker(_kunde3));
+        assertTrue(_vormerkkarte.istLeer());
+    }
+
+    @Test
+    public void testistVormerkenMoeglich()
+    {
+        Vormerkkarte vormerkkarteMoeglich = new Vormerkkarte(_medium);
+        assertTrue(vormerkkarteMoeglich.istVormerkenMoeglich(_kunde1));
+        vormerkkarteMoeglich.merkeVor(_kunde1);
+        vormerkkarteMoeglich.merkeVor(_kunde2);
+        vormerkkarteMoeglich.merkeVor(_kunde3);
+        assertFalse(vormerkkarteMoeglich.istVormerkenMoeglich(_kunde4));
+    }
+
+    @Test
+    public void testIstVormerker()
+    {
+        _vormerkkarte.merkeVor(_kunde1);
+        assertTrue(_vormerkkarte.istVormerker(_kunde1));
+        assertFalse(_vormerkkarte.istVormerker(_kunde2));
+    }
+
 }

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/medien/AbstractMediumTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/entitaeten/medien/AbstractMediumTest.java
@@ -52,8 +52,11 @@ public abstract class AbstractMediumTest
     {
         Medium medium = getMedium();
         Medium medium2 = getMedium();
-        assertNotEquals("Mehrere Exemplare des gleichen Mediums sollten ungleich", medium, medium2);
-        assertEquals("Dieselben Exemplare des gleichen Mediums sollten gleich", medium, medium);
+        assertNotEquals(
+                "Mehrere Exemplare des gleichen Mediums sollten ungleich",
+                medium, medium2);
+        assertEquals("Dieselben Exemplare des gleichen Mediums sollten gleich",
+                medium, medium);
     }
 
     @Test

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihServiceImplTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -19,6 +18,8 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.services.kundenstamm.Kundenst
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.kundenstamm.KundenstammServiceImpl;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.medienbestand.MedienbestandService;
 import de.uni_hamburg.informatik.swt.se2.mediathek.services.medienbestand.MedienbestandServiceImpl;
+import de.uni_hamburg.informatik.swt.se2.mediathek.services.vormerk.VormerkService;
+import de.uni_hamburg.informatik.swt.se2.mediathek.services.vormerk.VormerkServiceImpl;
 import de.uni_hamburg.informatik.swt.se2.mediathek.wertobjekte.Datum;
 import de.uni_hamburg.informatik.swt.se2.mediathek.wertobjekte.Kundennummer;
 
@@ -30,6 +31,7 @@ public class VerleihServiceImplTest
     private Datum _datum;
     private Kunde _kunde;
     private VerleihService _service;
+    private VormerkService _vormerkService;
     private List<Medium> _medienListe;
     private Kunde _vormerkkunde;
 
@@ -55,6 +57,8 @@ public class VerleihServiceImplTest
         medium = new CD("CD4", "baz", "foo", 123);
         medienbestand.fuegeMediumEin(medium);
         _medienListe = medienbestand.getMedien();
+
+        _vormerkService = new VormerkServiceImpl();
         _service = new VerleihServiceImpl(kundenstamm, medienbestand,
                 new ArrayList<Verleihkarte>());
     }
@@ -76,7 +80,7 @@ public class VerleihServiceImplTest
         // nicht verliehenen Medien an
         List<Medium> verlieheneMedien = _medienListe.subList(0, 2);
         List<Medium> nichtVerlieheneMedien = _medienListe.subList(2, 4);
-        _service.verleiheAn(_kunde, verlieheneMedien, _datum);
+        _service.verleiheAn(_kunde, verlieheneMedien, _datum, _vormerkService);
 
         // Prüfe, ob alle sondierenden Operationen für das Vertragsmodell
         // funktionieren
@@ -134,19 +138,20 @@ public class VerleihServiceImplTest
                 ereignisse[0] = true;
             }
         };
-        _service.verleiheAn(_kunde,
-                Collections.singletonList(_medienListe.get(0)), _datum);
+
+        _service.verleiheAn(_kunde, List.of(_medienListe.get(0)), _datum,
+                _vormerkService);
         assertFalse(ereignisse[0]);
 
         _service.registriereBeobachter(beobachter);
-        _service.verleiheAn(_kunde,
-                Collections.singletonList(_medienListe.get(1)), _datum);
+        _service.verleiheAn(_kunde, List.of(_medienListe.get(1)), _datum,
+                _vormerkService);
         assertTrue(ereignisse[0]);
 
         _service.entferneBeobachter(beobachter);
         ereignisse[0] = false;
-        _service.verleiheAn(_kunde,
-                Collections.singletonList(_medienListe.get(2)), _datum);
+        _service.verleiheAn(_kunde, List.of(_medienListe.get(2)), _datum,
+                _vormerkService);
         assertFalse(ereignisse[0]);
     }
 

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImplTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImplTest.java
@@ -27,175 +27,195 @@ import de.uni_hamburg.informatik.swt.se2.mediathek.wertobjekte.Kundennummer;
 
 public class VormerkServiceImplTest
 {
-    private final VerleihService _verleihService;
-    private final VormerkService _vormerkService;
+    private VerleihService _verleihService;
+    private VormerkService _vormerkService;
     private Kunde _ausleiher;
     private Kunde _ersterVormerker;
     private Kunde _zweiterVormerker;
     private Kunde _dritterVormerker;
     private Kunde _kunde;
-    
+
     private Medium _medium;
     private Medium _medium2;
-    
+
     public VormerkServiceImplTest()
     {
         _ausleiher = new Kunde(new Kundennummer(123456), "Max", "Mustermann");
         _ersterVormerker = new Kunde(new Kundennummer(234567), "Max", "Melone");
-        _zweiterVormerker = new Kunde(new Kundennummer(345678), "Moe", "Mustermann");
-        _dritterVormerker = new Kunde(new Kundennummer(456789), "Moe", "Melone");
+        _zweiterVormerker = new Kunde(new Kundennummer(345678), "Moe",
+                "Mustermann");
+        _dritterVormerker = new Kunde(new Kundennummer(456789), "Moe",
+                "Melone");
         _kunde = new Kunde(new Kundennummer(100110), "Bob", "Binaer");
-        
-        KundenstammService kundenstamm = new KundenstammServiceImpl(new ArrayList<Kunde>());
+
+        KundenstammService kundenstamm = new KundenstammServiceImpl(
+                new ArrayList<Kunde>());
         // kundenstamm mit testkunden befüllen
         kundenstamm.fuegeKundenEin(_ausleiher);
         kundenstamm.fuegeKundenEin(_ersterVormerker);
         kundenstamm.fuegeKundenEin(_zweiterVormerker);
         kundenstamm.fuegeKundenEin(_dritterVormerker);
         kundenstamm.fuegeKundenEin(_kunde);
-        
+
         _medium = new CD("CD1", "baz", "foo", 123);
         _medium2 = new CD("CD2", "bar", "fo", 124);
-        
-        MedienbestandService medienbestand = new MedienbestandServiceImpl(new ArrayList<Medium>());
-        
+
+        MedienbestandService medienbestand = new MedienbestandServiceImpl(
+                new ArrayList<Medium>());
+
         // medienbestand mit testmedien befüllen
-        
+
         medienbestand.fuegeMediumEin(_medium);
         medienbestand.fuegeMediumEin(_medium2);
-        
-        _verleihService = new VerleihServiceImpl(kundenstamm, medienbestand, new ArrayList<Verleihkarte>());
-        
-        
-        _vormerkService = new VormerkServiceImpl(_verleihService);
+
+        _vormerkService = new VormerkServiceImpl();
+        _verleihService = new VerleihServiceImpl(kundenstamm, medienbestand,
+                new ArrayList<Verleihkarte>());
     }
-    
+
     @Test
     public void testLeereVormerkkarten()
     {
-        assertTrue(_vormerkService.getVormerkkarte(_medium).istLeer());
+        assertTrue(_vormerkService.getVormerkkarte(_medium)
+            .istLeer());
     }
-    
+
     @Test
     public void testMerkeVor()
     {
-        _vormerkService.merkeVor(_ersterVormerker, _medium);
-        _vormerkService.merkeVor(_zweiterVormerker, _medium);
-        _vormerkService.merkeVor(_dritterVormerker, _medium);
+        _vormerkService.merkeVor(_ersterVormerker, _medium, _verleihService);
+        _vormerkService.merkeVor(_zweiterVormerker, _medium, _verleihService);
+        _vormerkService.merkeVor(_dritterVormerker, _medium, _verleihService);
         Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(_medium);
-        
+
         assertEquals(vormerkkarte.getMedium(), _medium);
         assertEquals(vormerkkarte.getErsterVormerker(), _ersterVormerker);
         assertEquals(vormerkkarte.getZweiterVormerker(), _zweiterVormerker);
         assertEquals(vormerkkarte.getDritterVormerker(), _dritterVormerker);
     }
-    
+
     @Test
     public void testAusleiherIstVormerkenMoeglich()
     {
         Datum datum = new Datum(3, 9, 2042);
         try
         {
-            _verleihService.verleiheAn(_ausleiher, List.of(_medium), datum);
+            _verleihService.verleiheAn(_ausleiher, List.of(_medium), datum, _vormerkService);
         }
         catch (ProtokollierException e)
         {
             // ignorieren, hat nix mit dem testen zu tun
         }
-        
+
         // der Ausleiher darf die DVD NICHT vormerken
-        assertFalse(_vormerkService.istVormerkenMoeglich(_ausleiher, _medium));
-        
+        assertFalse(_vormerkService.istVormerkenMoeglich(_ausleiher, _medium, _verleihService));
+
         try
         {
-            _verleihService.nimmZurueck(List.of(_medium), new Datum(1, 1, 2054));            
-        } catch (ProtokollierException e) {
+            _verleihService.nimmZurueck(List.of(_medium),
+                    new Datum(1, 1, 2054));
+        }
+        catch (ProtokollierException e)
+        {
             // wir ignorieren protokollier zeugs
         }
-        
+
         // jetzt sollte der Ausleiher das Medium vormerken dürfen
-        
-        assertTrue(_vormerkService.istVormerkenMoeglich(_ausleiher, _medium));
+
+        assertTrue(_vormerkService.istVormerkenMoeglich(_ausleiher, _medium, _verleihService));
     }
-    
+
     @Test
     public void testIstVormerkenUnmoeglichDarfNichtDoppelt()
     {
-        _vormerkService.merkeVor(_ersterVormerker, _medium);
-        assertFalse(_vormerkService.istVormerkenMoeglich(_ersterVormerker, _medium));
+        _vormerkService.merkeVor(_ersterVormerker, _medium, _verleihService);
+        assertFalse(_vormerkService.istVormerkenMoeglich(_ersterVormerker,
+                _medium, _verleihService));
     }
-    
+
     @Test
     public void testIstVormerkenMoeglich()
     {
         // (0 Vormerker)
-        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium));
-        
-        _vormerkService.merkeVor(_ersterVormerker, _medium);
-        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium));
-        
-        _vormerkService.merkeVor(_zweiterVormerker, _medium);
-        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium));
+        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium, _verleihService));
 
-        _vormerkService.merkeVor(_dritterVormerker, _medium);
-        assertFalse(_vormerkService.istVormerkenMoeglich(_kunde, _medium));
+        _vormerkService.merkeVor(_ersterVormerker, _medium, _verleihService);
+        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium, _verleihService));
+
+        _vormerkService.merkeVor(_zweiterVormerker, _medium, _verleihService);
+        assertTrue(_vormerkService.istVormerkenMoeglich(_kunde, _medium, _verleihService));
+
+        _vormerkService.merkeVor(_dritterVormerker, _medium, _verleihService);
+        assertFalse(_vormerkService.istVormerkenMoeglich(_kunde, _medium, _verleihService));
 
     }
-    
+
     @Test
     public void testEntferneErstenVormerker()
     {
-    	_vormerkService.merkeVor(_ersterVormerker, _medium);
-    	_vormerkService.merkeVor(_zweiterVormerker, _medium);
-    	_vormerkService.merkeVor(_dritterVormerker, _medium);
-    	
-    	// entfernen des ersten Vormerkers (erfolgreich)
-    	_vormerkService.entferneErstenVormerker(_ersterVormerker, List.of(_medium));
-    	
-    	Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(_medium);
-    	assertEquals(_zweiterVormerker, vormerkkarte.getErsterVormerker());
-    	assertEquals(_dritterVormerker, vormerkkarte.getZweiterVormerker());
-    	assertNull(vormerkkarte.getDritterVormerker());
-    	
-    	// ersten Vormerker erneut entfernen, (sollte nicht erfolgreich sein, da er nicht mehr erster Vormerker ist)
-    	_vormerkService.entferneErstenVormerker(_ersterVormerker, List.of(_medium));
-    	assertEquals(_zweiterVormerker, vormerkkarte.getErsterVormerker());
-    	assertEquals(_dritterVormerker, vormerkkarte.getZweiterVormerker());
-    	assertNull(vormerkkarte.getDritterVormerker());
-    	
-    	// entfernen des jetzigen ersten Vormerkers, also zweiterVormerker
-    	_vormerkService.entferneErstenVormerker(_zweiterVormerker, List.of(_medium));
-    	assertEquals(_dritterVormerker, vormerkkarte.getErsterVormerker());
-    	assertNull(vormerkkarte.getZweiterVormerker());
-    	assertNull(vormerkkarte.getDritterVormerker());
-    	
-    	// entfernen des jetzigen ersten Vormerkers, also dritterVormerker
-    	_vormerkService.entferneErstenVormerker(_dritterVormerker, List.of(_medium));
-    	assertTrue(vormerkkarte.istLeer());
+        _vormerkService.merkeVor(_ersterVormerker, _medium, _verleihService);
+        _vormerkService.merkeVor(_zweiterVormerker, _medium, _verleihService);
+        _vormerkService.merkeVor(_dritterVormerker, _medium, _verleihService);
+
+        // entfernen des ersten Vormerkers (erfolgreich)
+        _vormerkService.entferneErstenVormerker(_ersterVormerker,
+                List.of(_medium));
+
+        Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(_medium);
+        assertEquals(_zweiterVormerker, vormerkkarte.getErsterVormerker());
+        assertEquals(_dritterVormerker, vormerkkarte.getZweiterVormerker());
+        assertNull(vormerkkarte.getDritterVormerker());
+
+        // ersten Vormerker erneut entfernen, (sollte nicht erfolgreich sein, da er nicht mehr erster Vormerker ist)
+        _vormerkService.entferneErstenVormerker(_ersterVormerker,
+                List.of(_medium));
+        assertEquals(_zweiterVormerker, vormerkkarte.getErsterVormerker());
+        assertEquals(_dritterVormerker, vormerkkarte.getZweiterVormerker());
+        assertNull(vormerkkarte.getDritterVormerker());
+
+        // entfernen des jetzigen ersten Vormerkers, also zweiterVormerker
+        _vormerkService.entferneErstenVormerker(_zweiterVormerker,
+                List.of(_medium));
+        assertEquals(_dritterVormerker, vormerkkarte.getErsterVormerker());
+        assertNull(vormerkkarte.getZweiterVormerker());
+        assertNull(vormerkkarte.getDritterVormerker());
+
+        // entfernen des jetzigen ersten Vormerkers, also dritterVormerker
+        _vormerkService.entferneErstenVormerker(_dritterVormerker,
+                List.of(_medium));
+        assertTrue(vormerkkarte.istLeer());
     }
-    
+
     @Test
     public void testEntferneErstenVormerkerOhneVormerker()
     {
-    	// versuchen Vormerker zu entfernen, obwohl derzeit kein Vormerker vorhanden ist
-    	_vormerkService.entferneErstenVormerker(_ersterVormerker, List.of(_medium));
-    	
-    	Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(_medium);
-    	assertTrue(vormerkkarte.istLeer());
+        // versuchen Vormerker zu entfernen, obwohl derzeit kein Vormerker vorhanden ist
+        _vormerkService.entferneErstenVormerker(_ersterVormerker,
+                List.of(_medium));
+
+        Vormerkkarte vormerkkarte = _vormerkService.getVormerkkarte(_medium);
+        if (vormerkkarte == null)
+        {
+            vormerkkarte = new Vormerkkarte(_medium);
+            ((VormerkServiceImpl) _vormerkService)._vormerkkarten.put(_medium,
+                    vormerkkarte);
+        }
+        assertTrue(vormerkkarte.istLeer());
     }
-    
+
     @Test
     public void testEntferneErstenVormerkerMehrereMedien()
     {
-    	_vormerkService.merkeVor(_ersterVormerker, _medium);
-    	_vormerkService.merkeVor(_ersterVormerker, _medium2);
-    	
-    	// ersten Vormerker für mehrere Medien entfernen
-    	_vormerkService.entferneErstenVormerker(_ersterVormerker, List.of(_medium, _medium2));
-    	
-    	Vormerkkarte vormerkkarte1 = _vormerkService.getVormerkkarte(_medium);
-    	Vormerkkarte vormerkkarte2 = _vormerkService.getVormerkkarte(_medium2);
-    	assertTrue(vormerkkarte1.istLeer());
-    	assertTrue(vormerkkarte2.istLeer());
+        _vormerkService.merkeVor(_ersterVormerker, _medium, _verleihService);
+        _vormerkService.merkeVor(_ersterVormerker, _medium2, _verleihService);
+
+        // ersten Vormerker für mehrere Medien entfernen
+        _vormerkService.entferneErstenVormerker(_ersterVormerker,
+                List.of(_medium, _medium2));
+
+        Vormerkkarte vormerkkarte1 = _vormerkService.getVormerkkarte(_medium);
+        Vormerkkarte vormerkkarte2 = _vormerkService.getVormerkkarte(_medium2);
+        assertTrue(vormerkkarte1.istLeer());
+        assertTrue(vormerkkarte2.istLeer());
     }
 }

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/rueckgabe/VerleihkartenTableModelTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/rueckgabe/VerleihkartenTableModelTest.java
@@ -51,6 +51,7 @@ public class VerleihkartenTableModelTest
         List<Verleihkarte> verleihkarten = new ArrayList<Verleihkarte>();
         verleihkarten.add(_karte1);
         verleihkarten.add(_karte2);
+
         _verleihService = new VerleihServiceImpl(kundenstamm, medienbestand,
                 verleihkarten);
         _model = new VerleihkartenTableModel();


### PR DESCRIPTION
VormerkServiceImpl und VerleihServiceImpl halten nichtmehr Referezen aufeinander, stattdessen muss bein Aufruf von bestimmten Methoden von vormerkService und VerleihService der jeweils andere Service übergeben werden, dies hätte sich auch durch eine Setter-Methode nach der Instanziierung eines Services realisieren lassen, das Downcasting eines Services in einen Subtyp sollte vermieden werden. Der "ausleihen"-Knopf in der Ausleih-Ansicht lässt sich nun nur betätigen, sofern alle Medien auch nach den Kriterien des Vormerkens ausgeliehen werden dürfen. Wird ein Medium, welches vorgemerkt war, ausgeliehen, so wird der erste Vormerker, der nun der Ausleiher ist, entfernt. Die restlichen Vormerker des Mediums rücken nach.