### PR TITLE
istVormerkenMoeglich() in VormerkWerkzeug um eine erweiterte for-Schleife ergänzt

### DIFF
--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/ui/vormerken/VormerkWerkzeug.java
@@ -224,6 +224,15 @@ public class VormerkWerkzeug
         // werden. Ist dies korrekt implementiert, wird der Vormerk-Button gemäß
         // der Anforderungen a), b), c) und e) aktiviert.
         boolean vormerkenMoeglich = (kunde != null) && !medien.isEmpty();
+        for (Medium medium : medien)
+        {
+            if (!_vormerkService.istVormerkenMoeglich(kunde, medium,
+                    _verleihService))
+            {
+                vormerkenMoeglich = false;
+                break;
+            }
+        }
 
         return vormerkenMoeglich;
     }


### PR DESCRIPTION
Damit der Vormerk-Button ausgegraut wird, wenn das vormerken nicht möglich ist, musste istVormerkenMoeglich() in VormerkWerkzeug überprüfen, dass Kunden Zum Beispiel nicht bereits Ausleiher oder Vormerker sind