### PR TITLE
Überflüssige Methoden aus VormerkServiceImpl entfernt

### DIFF
--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImpl.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/mediathek/services/vormerk/VormerkServiceImpl.java
@@ -88,44 +88,6 @@ public class VormerkServiceImpl extends AbstractObservableService
         informiereUeberAenderung();
     }
 
-    /**
-     * Entfernt den ersten Vormerker eines Mediums.
-     * 
-     * @param kunde der Kunde, der ggf. Vormerker war
-     * @param medium das Medium
-     * 
-     * @require kunde != null
-     * @require medium != null
-     * 
-     * @return ob das Entfernen des ersten Vormerkers erfolgreich war
-     */
-    private boolean entferneErstenVormerker(Kunde kunde, Medium medium)
-    {
-        assert kunde != null : "Vorbedingung verletzt: kunde != null";
-        assert medium != null : "Vorbedingung verletzt: medium != null";
-
-        Vormerkkarte vormerkkarte = getVormerkkarte(medium);
-        if (kunde.equals(vormerkkarte.getErsterVormerker()))
-        {
-            vormerkkarte.entferneErstenVormerker();
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    public void entferneVormerker(Medium medium, Kunde kunde)
-    {
-        Vormerkkarte vormerkkarte = getVormerkkarte(medium);
-        if (kunde.equals(vormerkkarte.getErsterVormerker()))
-        {
-            vormerkkarte.entferneErstenVormerker();
-            informiereUeberAenderung();
-        }
-    }
-
     @Override
     public boolean istVormerkerOderLeereVormerkkarte(Kunde kunde,
             List<Medium> medien)


### PR DESCRIPTION
Die Methoden entferneErstenVormerker und entferneVormerker in VormerkServiceImpl wurden nicht mehr benutzt und jetzt entfernt