### PR TITLE
fix: toString für negative Geldbeträge im Cent-Bereich

### DIFF
--- a/src/main/java/de/uni_hamburg/informatik/swt/se2/kino/wertobjekte/Geldbetrag.java
+++ b/src/main/java/de/uni_hamburg/informatik/swt/se2/kino/wertobjekte/Geldbetrag.java
@@ -129,8 +129,12 @@ public record Geldbetrag(int eurocent) {
         // + cent = 30
         // also "-31314,30" <- geht nicht auf!
         
+        boolean negativ = eurocent < 0; 
+        
         int euro = eurocent / 100;
-        String euroString = Integer.toString(euro);
+        
+        // Math.abs, weil wir - separat behandeln
+        String euroString = Integer.toString(Math.abs(euro));
         String paddedEuroString = StringUtils.pad(euroString, MIN_EURO_STELLEN, '0', LeftRight.LEFT);
         
         // wir wollen nicht dass hier ggf. auch noch ein - steht!
@@ -139,6 +143,7 @@ public record Geldbetrag(int eurocent) {
         String paddedCentString = StringUtils.pad(centString, CENT_STELLEN, '0', LeftRight.LEFT);
 
         return new StringBuilder()
+                .append(negativ ? "-" : "")
                 .append(paddedEuroString)
                 .append(',')
                 .append(paddedCentString)

--- a/src/test/java/de/uni_hamburg/informatik/swt/se2/kino/wertobjekte/GeldbetragTest.java
+++ b/src/test/java/de/uni_hamburg/informatik/swt/se2/kino/wertobjekte/GeldbetragTest.java
@@ -51,6 +51,9 @@ public class GeldbetragTest
         
         Geldbetrag negativ = new Geldbetrag(-10040);
         assertEquals("-100,40", negativ.toString());
+        
+        Geldbetrag negativImCentbereich = new Geldbetrag(-10);
+        assertEquals("-00,10", negativImCentbereich.toString());
     }
     
     @Test


### PR DESCRIPTION
Die Geldbetrag.toString() Methode wurde überarbeitete, sodass sie bei negativen Geldbeträgen im Cent-Bereich nun auch korrekte Werte zurückgibt. Tests dafür wurden hinzugefügt.